### PR TITLE
Add Option add-in to customize frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ p := pin.New("message", /* options... */)
 - `WithFailSymbolColor(color Color)` – sets the color of the failure symbol.
 - `WithFailColor(color Color)` – sets the color of the failure message text.
 - `WithPosition(pos Position)` – sets the spinner's position relative to the message.
+- `WithSpinnerFrames(frames []rune)` – sets the spinner's frames.
 - `WithWriter(w io.Writer)` – sets a custom writer for spinner output.
 
 ### Available Colors

--- a/pin.go
+++ b/pin.go
@@ -186,6 +186,9 @@ func WithFailColor(color Color) Option {
 	}
 }
 
+// WithSpinnerFrames sets the frames for the spinner.
+// If not set, defaults to the braille symbols. The frames are used from
+// beginning to end and then start at the beginning (frames[0]) again
 func WithSpinnerFrames(frames []rune) Option {
 	return func(p *Pin) {
 		p.frames = frames

--- a/pin.go
+++ b/pin.go
@@ -186,6 +186,12 @@ func WithFailColor(color Color) Option {
 	}
 }
 
+func WithSpinnerFrames(frames []rune) Option {
+	return func(p *Pin) {
+		p.frames = frames
+	}
+}
+
 // WithWriter sets a custom io.Writer for spinner output.
 func WithWriter(w io.Writer) Option {
 	return func(p *Pin) {

--- a/pin_test.go
+++ b/pin_test.go
@@ -582,3 +582,23 @@ func TestFailWithoutCustomFailColorUsesTextColor(t *testing.T) {
 		t.Errorf("Expected output to contain text color ANSI code %q, got: %q", expectedTextColorCode, output)
 	}
 }
+
+// TestAllColors verifies that custom spinner configs work correctly
+// Note that since spinner frames only show up on proper terminals and thus
+// can't be captured, we can't really verify that they were emitted.
+func TestSpinnerFrames(t *testing.T) {
+	framesets := []string{
+		".oO0Oo",
+		"|/-\\",
+	}
+
+	for _, frames := range framesets {
+		p := pin.New("Testing",
+			pin.WithSpinnerFrames([]rune(frames)),
+		)
+		cancel := p.Start(context.Background())
+		time.Sleep(250 * time.Millisecond)
+		p.Stop("Done")
+		cancel()
+	}
+}


### PR DESCRIPTION
Can be used like so:

```
      p := pin.New("Processing...",
          pin.WithSpinnerFrames([]rune{'.', 'o', 'O', '0', 'O', 'o'}),
      )
```